### PR TITLE
[PyTorch] Fix crash during program shutdown if initialize_ub is called

### DIFF
--- a/examples/pytorch/comm_gemm_overlap/ln_mlp_with_overlap.py
+++ b/examples/pytorch/comm_gemm_overlap/ln_mlp_with_overlap.py
@@ -224,4 +224,3 @@ if __name__ == "__main__":
             env=os.environ,
             check=True,
         )
-    os._exit(0)

--- a/tests/pytorch/distributed/run_transformer_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_transformer_layer_with_overlap.py
@@ -270,17 +270,12 @@ def train(opts):
 
 
 if __name__ == "__main__":
-    try:
-        if "TORCHELASTIC_RUN_ID" in os.environ.keys():
-            args = parse_args()
-            os._exit(train(args))
-        else:
-            subprocess.run(
-                ["torchrun", f"--nproc-per-node={torch.cuda.device_count()}", *sys.argv],
-                env=os.environ,
-                check=True,
-            )
-            os._exit(0)
-    except Exception as err:  # pylint: disable=broad-exception-caught
-        print(err)
-        os._exit(1)
+    if "TORCHELASTIC_RUN_ID" in os.environ.keys():
+        args = parse_args()
+        sys.exit(train(args))
+    else:
+        subprocess.run(
+            ["torchrun", f"--nproc-per-node={torch.cuda.device_count()}", *sys.argv],
+            env=os.environ,
+            check=True,
+        )

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -443,12 +443,19 @@ void multi_tensor_sgd_cuda(int chunk_size, at::Tensor noop_flag,
  * Comm+GEMM overlap
  **************************************************************************************************/
 
+namespace transformer_engine_torch {
+
+struct TorchDistCallbacks : torch::CustomClassHolder {
+  std::function<void(at::Tensor &, at::Tensor &, const std::string &)> allgather;
+  std::function<void(at::Tensor &, int64_t, const std::string &)> bcast;
+  std::function<void(const std::string &)> barrier;
+};
 void set_comm_overlap_callbacks(
+  TorchDistCallbacks *callback_holder,
   std::function<void(at::Tensor &, at::Tensor &, const std::string &)> allgather_callback,
   std::function<void(at::Tensor &, int64_t, const std::string &)> bcast_callback,
   std::function<void(const std::string &)> barrier_callback);
 
-namespace transformer_engine_torch {
 
 class CommGemmOverlap : public torch::CustomClassHolder,
                         public transformer_engine::common::CommGemmOverlap {

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -241,7 +241,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .export_values();
 
   // Comm+GEMM Overlap
-  m.def("set_comm_overlap_callbacks", &set_comm_overlap_callbacks);
+  py::class_<te_torch::TorchDistCallbacks>(m, "TorchDistCallbacks")
+    .def(py::init<>());
+  m.attr("_dist_callback_holder") = py::cast(
+    std::make_unique<te_torch::TorchDistCallbacks>(), 
+    py::return_value_policy::take_ownership //module m track its lifecycle
+  );
+  m.def("set_comm_overlap_callbacks", &te_torch::set_comm_overlap_callbacks,
+    py::arg("callback_holder").none(false), //to reject None
+    py::arg("allgather_callback"),
+    py::arg("bcast_callback"),
+    py::arg("barrier_callback")
+  );
 
   py::class_<te_torch::CommGemmOverlap>(m, "CommGemmOverlap", py::module_local())
       .def(py::init</* sample_tensor */ torch::Tensor &, /* world_rank */ int, /* world_size */ int,

--- a/transformer_engine/pytorch/module/base.py
+++ b/transformer_engine/pytorch/module/base.py
@@ -324,7 +324,7 @@ def initialize_ub(
     def barrier_callback(group: str):
         torch.distributed.barrier(group=ub_pgs[group])
 
-    tex.set_comm_overlap_callbacks(allgather_callback, bcast_callback, barrier_callback)
+    tex.set_comm_overlap_callbacks(tex._dist_callback_holder, allgather_callback, bcast_callback, barrier_callback)
 
     if ub_cfgs is not None:
         for name in dgrad_reduce_scatter_overlap:


### PR DESCRIPTION
- Given there are some python wrapper object generated by pybind, for C++ API to calls via std::function to python method,
- These python wrapper object are associated with the struct C 

BEFORE: The static C struct is destoryed too late at the program exit. It seems fail to free these wrapper because most python-related object has gone.(like GIL) 

AFTER: Associate the C struct with module, so that it can be released at the time module been freed.
Signed-off-by: Anderson Meng <ameng@nvidia.com>

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refractor

## Changes

Please list the changes introduced in this PR:

- Make UB GEMM can gracefully exit w/o forcely `os._exit()`
- Remove `os._exit()` in examples/tests

# Checklist:

- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
